### PR TITLE
fix: Fixed paths on repository url and homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
 	"name": "phx-tools",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
+	"license": "MIT",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
+	"author": "Robert-W <rwinterbottom@asymmetrik.com>",
 	"scripts": {
 		"test": "jest packages",
 		"lint": "eslint \"packages/**/*.js\"",

--- a/packages/fhir-gql-schema-utils/package.json
+++ b/packages/fhir-gql-schema-utils/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.1",
   "description": "Suite of FHIR related utilities for GraphQL schemas.",
   "main": "index.js",
-  "repository": "https://github.com/Asymmetrik/phx-tools/tree/master/packages/fhir-gql-schema-utils",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fhir-sanitize-param/package.json
+++ b/packages/fhir-sanitize-param/package.json
@@ -3,10 +3,14 @@
   "version": "0.9.1",
   "description": "Sanitization tool for FHIR parameters",
   "main": "index.js",
-  "repository": "https://github.com/Asymmetrik/phx-tools/tree/master/packages/fhir-sanitize-param",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",
   "private": true,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sof-graphql-invariant/package.json
+++ b/packages/sof-graphql-invariant/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.2",
   "description": "Smart on FHIR scope checker for GraphQL",
   "main": "index.js",
-  "repository": "https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-graphql-invariant",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sof-scope-checker/package.json
+++ b/packages/sof-scope-checker/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.1",
   "description": "Smart on FHIR scope checker",
   "main": "index.js",
-  "repository": "https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-scope-checker",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sof-strategy/package.json
+++ b/packages/sof-strategy/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.2",
   "description": "Smart on FHIR authorization strategy for passport",
   "main": "index.js",
-  "repository": "https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-strategy",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
There were issues with generated changelogs from lerna containing invalid urls for PR's, commits, and other things. This was because the base url being used was incorrectly set in our package.json files. This PR updates all the homepage and repository urls in all package.json's to be set to the base url.