### PR TITLE
Package/fhir response utils

### DIFF
--- a/packages/fhir-response-util/README.md
+++ b/packages/fhir-response-util/README.md
@@ -1,0 +1,325 @@
+# FHIR Response Utility
+> Utility for handling the headers, content, and status types for a response
+
+## Install
+
+```shell
+yarn add @asymmetrik/fhir-response-util
+```
+
+## Usage
+The response utility exposes the following methods which can be used to for different scenarios and different types of responses. They all make certain assumptions about the arguments they receive which are documented below in the [arguments](#arguments) section.
+
+This is designed to be used in [node-fhir-server-core](https://github.com/Asymmetrik/node-fhir-server-core) and similar FHIR servers. There is some pseudocode with each method's description to give an idea of how this might work. If you read the source code for resource controllers in node-fhir-server-core, you can see how we are using this internally. 
+
+### read
+> Used when you are returning a Bundle of resources
+
+This will set the correct Content-Type and status code while sending the json back to the client.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function getPatientsController (req, res, next) {
+  // The user may have some service to fetch results
+  service.getPatients(req).then(bundle => {
+    // Assuming bundle contains a bunch of patients
+    handler.read(req, res, bundle);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+### readOne
+> Used when you are returning a single resource of any type.
+
+This will set the correct Content-Type and status code while sending the json back to the client.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function getPatientController (req, res, next) {
+  // The user may have some service to fetch results
+  service.getPatient(req).then(patient => {
+    handler.readOne(req, res, patient);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+### create
+> Used when you are creating a single resource of any type.
+
+This will set the correct Content-Location, Location, and ETag headers. As well as set the correct status code.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function createPatientController (req, res, next) {
+  // The user may have some service to fetch results
+  service.create(req).then(patient => {
+    let json = { id: patient.id, resource_version: patient.meta.versionId };
+    let options = { type: 'Patient' };
+    
+    handler.create(req, res, json, options);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+### update
+> Used when you are updating a single resource of any type
+
+This will set the correct Content-Location, Last-Modified, Location, and ETag headers. As well as set the correct Content-Type and status code.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function updatePatientController (req, res, next) {
+  // The user may have some service to fetch results
+  service.update(req).then(patient => {
+    let json = { id: patient.id, resource_version: patient.meta.versionId, created: false };
+    let options = { type: 'Patient' };
+    
+    handler.update(req, res, json, options);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+### remove
+> Used when you are deleting a single resource of any type
+
+This will set the correct ETag header and status code.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function removePatientController (req, res, next) {
+  // The user may have some service to fetch results
+  service.remove(req).then(id => {
+    let json = { deleted: id };
+    
+    handler.remove(req, res, json);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+### history
+> Used when you are querying the history of a resource of any type
+
+This will set the correct Content-Type and status code while sending the json back to the client.
+
+```javascript
+const handler = require('@asymmetrik/fhir-response-util');
+
+// Some controller
+function getPatientHistoryController (req, res, next) {
+  // The user may have some service to fetch results
+  service.history(req).then(bundle => {
+    handler.history(req, res, bundle);
+  }).catch(err => {
+    next(err);
+  });
+}
+```
+
+## Arguments
+[`req`](https://expressjs.com/en/api.html#req) and [`res`](https://expressjs.com/en/api.html#res) that you see in each method are from express. `res` is just a normal response, but request must have a base_version parameter(`req.params.base_version`). Specifically, it should be one of the valid versions we support in our server, which are '1_0_2', '3_0_1', and '4_0_0'. If you would like us to add more versions for this, just let us know, we use this to determine the correct content-type as well as the url of the resource for the response type and response headers.
+
+### read
+> handler.read(req, res, json);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true` 
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true` 
+
+#### `json`
+Bundle FHIR resource.
+
+Type: `Object`  
+Required: `true` 
+
+### readOne
+> handler.readOne(req, res, json);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `json`
+Individual FHIR resource.
+
+Type: `Object`  
+Required: `true`
+
+### create
+> handler.create(req, res, json, options);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `json`
+Properties from the results. Must have an `id`
+
+Type: `Object`  
+Required: `true`
+
+#### `json.id`
+ID of the FHIR resource that was created.
+
+Type: `String`  
+Required: `true`
+
+#### `json.resource_version`
+If we are using history, which version of the resource did we create.
+
+Type: `String`  
+Required: `false`
+
+#### `options`
+Additional options needed to set the correct headers in the response.
+
+Type: `Object`  
+Required: `true`
+
+#### `options.type`
+This helps us set the content-location and location headers. For example, `handler.create(req, res, json, { type: 'Patient' })` would allow us to set a header like this, `res.set('Location', '4_0_0/Patient/patient-identifier')`.
+
+Type: 'String'  
+Required: 'true'
+
+### update
+> handler.update(req, res, json, options);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `json`
+Properties from the results. Must have an `id`
+
+Type: `Object`  
+Required: `true`
+
+#### `json.id`
+ID of the FHIR resource that was created.
+
+Type: `String`  
+Required: `true`
+
+#### `json.resource_version`
+If we are using history, which version of the resource did we create.
+
+Type: `String`  
+Required: `false`
+
+#### `json.created`
+Did we create a resource or not. If we created a resource, we need to know so that we can set a `res.status` of 201, otherwise, we will default to a status of 200.
+
+Type: `Boolean`  
+Required: `false`
+
+#### `options`
+Additional options needed to set the correct headers in the response.
+
+Type: `Object`  
+Required: `true`
+
+#### `options.type`
+This helps us set the content-location and location headers. For example, `handler.create(req, res, json, { type: 'Patient' })` would allow us to set a header like this, `res.set('Location', '4_0_0/Patient/patient-identifier')`.
+
+Type: 'String'  
+Required: 'true'
+
+### remove
+> handler.remove(req, res, json);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `json`
+JSON for the response. Not required but contains the optional deleted property.
+
+Type: `Object`  
+Required: `false`
+
+#### `json.deleted`
+The deleted property should be the id of the element deleted. For example, `handler.remove(req, res, { deleted: 'qwerty-123' })`. This allows us to add the identifier as a ETag in the response header.
+
+Type: `Object`  
+Required: `false`
+
+### history
+> handler.history(req, res, json);
+
+#### `req`
+Express request.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `res`
+Express response.
+
+Type: `Express.req`  
+Required: `true`
+
+#### `json`
+Bundle FHIR resource.
+
+Type: `Object`  
+Required: `true`

--- a/packages/fhir-response-util/index.js
+++ b/packages/fhir-response-util/index.js
@@ -64,10 +64,7 @@ function create(req, res, json, options) {
 
 	if (json.resource_version) {
 		let pathname = path.posix.join(location, '_history', json.resource_version);
-		res.set(
-			'Content-Location',
-			`${baseUrl}/${pathname}`,
-		);
+		res.set('Content-Location', `${baseUrl}/${pathname}`);
 		res.set('ETag', json.resource_version);
 	}
 
@@ -92,10 +89,7 @@ function update(req, res, json, options) {
 
 	if (json.resource_version) {
 		let pathname = path.posix.join(location, '_history', json.resource_version);
-		res.set(
-			'Content-Location',
-			`${baseUrl}/${pathname}`,
-		);
+		res.set('Content-Location', `${baseUrl}/${pathname}`);
 		res.set('ETag', json.resource_version);
 	}
 

--- a/packages/fhir-response-util/index.js
+++ b/packages/fhir-response-util/index.js
@@ -42,7 +42,7 @@ function readOne(req, res, json) {
 
 	if (json && json.meta) {
 		res.set('Last-Modified', json.meta.lastUpdated);
-		res.set('ETag', json.meta.versionId);
+		res.set('ETag', `W/"${json.meta.versionId}"`);
 	}
 
 	res.type(getContentType(fhirVersion));

--- a/packages/fhir-response-util/index.js
+++ b/packages/fhir-response-util/index.js
@@ -1,0 +1,144 @@
+const path = require('path');
+
+/**
+ * @function getContentType
+ * @description Get the correct application type for the response
+ * @param {String} version Version of resources we are working with
+ */
+function getContentType(version) {
+	switch (version) {
+		case '1_0_2':
+			return 'application/json+fhir';
+		case '3_0_1':
+		case '4_0_0':
+			return 'application/fhir+json';
+		default:
+			return 'application/json';
+	}
+}
+
+/**
+ * @function read
+ * @description Used when you are returning a Bundle of resources
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ */
+function read(req, res, json) {
+	let fhirVersion = req.params.base_version;
+	res.type(getContentType(fhirVersion));
+	res.status(200).json(json);
+}
+
+/**
+ * @function readOne
+ * @description Used when you are returning a single resource of any type
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ */
+function readOne(req, res, json) {
+	let fhirVersion = req.params.base_version;
+
+	if (json && json.meta) {
+		res.set('Last-Modified', json.meta.lastUpdated);
+		res.set('ETag', json.meta.versionId);
+	}
+
+	res.type(getContentType(fhirVersion));
+	res.status(200).json(json);
+}
+
+/**
+ * @function create
+ * @description Used when you are creating a single resource of any type
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ * @param {Object} options - Any additional options necessary to generate response
+ */
+function create(req, res, json, options) {
+	let fhirVersion = req.params.base_version;
+	let baseUrl = `${req.protocol}://${req.get('host')}`;
+	let location = `${fhirVersion}/${options.type}/${json.id}`;
+
+	if (json.resource_version) {
+		let pathname = path.posix.join(location, '_history', json.resource_version);
+		res.set(
+			'Content-Location',
+			`${baseUrl}/${pathname}`,
+		);
+		res.set('ETag', json.resource_version);
+	}
+
+	res.set('Location', location);
+	res.status(201).end();
+}
+
+/**
+ * @function update
+ * @description Used when you are updating a single resource of any type
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ * @param {Object} options - Any additional options necessary to generate response
+ */
+function update(req, res, json, options) {
+	let fhirVersion = req.params.base_version;
+	let baseUrl = `${req.protocol}://${req.get('host')}`;
+	let location = `${fhirVersion}/${options.type}/${json.id}`;
+	let status = json.created ? 201 : 200;
+	let date = new Date();
+
+	if (json.resource_version) {
+		let pathname = path.posix.join(location, '_history', json.resource_version);
+		res.set(
+			'Content-Location',
+			`${baseUrl}/${pathname}`,
+		);
+		res.set('ETag', json.resource_version);
+	}
+
+	res.set('Last-Modified', date.toISOString());
+	res.type(getContentType(fhirVersion));
+	res.set('Location', location);
+	res.status(status).end();
+}
+
+/**
+ * @function remove
+ * @description Used when you are deleting a single resource of any type
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ */
+function remove(_req, res, json) {
+	if (json && json.deleted) {
+		res.set('ETag', json.deleted);
+	}
+
+	res.status(204).end();
+}
+
+/**
+ * @function history
+ * @description Used when you are querying the history of a resource of any type
+ * @param {Express.req} req - Express request object
+ * @param {Express.res} res - Express response object
+ * @param {Object} json - json to send to client
+ */
+function history(req, res, json) {
+	let version = req.params.base_version;
+	res.type(getContentType(version));
+	res.status(200).json(json);
+}
+
+module.exports = {
+	getContentType,
+	read,
+	readOne,
+	create,
+	update,
+	remove,
+	history,
+};

--- a/packages/fhir-response-util/index.test.js
+++ b/packages/fhir-response-util/index.test.js
@@ -84,7 +84,7 @@ describe('FHIR Response Utility', () => {
 			expect(res.set.mock.calls[0][0]).toBe('Last-Modified');
 			expect(res.set.mock.calls[0][1]).toBe(results.meta.lastUpdated);
 			expect(res.set.mock.calls[1][0]).toBe('ETag');
-			expect(res.set.mock.calls[1][1]).toBe(results.meta.versionId);
+			expect(res.set.mock.calls[1][1]).toBe(`W/"${results.meta.versionId}"`);
 
 			expect(res.status.mock.calls).toHaveLength(1);
 			expect(res.status.mock.calls[0][0]).toBe(200);

--- a/packages/fhir-response-util/index.test.js
+++ b/packages/fhir-response-util/index.test.js
@@ -4,8 +4,8 @@ let req = {
 	protocol: 'https',
 	get: _prop => 'localhost:3000',
 	params: {
-		base_version: '4_0_0'
-	}
+		base_version: '4_0_0',
+	},
 };
 
 let res, end, json;
@@ -19,8 +19,8 @@ describe('FHIR Response Utility', () => {
 			type: jest.fn(),
 			status: jest.fn(() => ({
 				end: end,
-				json: json
-			}))
+				json: json,
+			})),
 		};
 	});
 
@@ -74,8 +74,8 @@ describe('FHIR Response Utility', () => {
 				results: 'GOLD',
 				meta: {
 					lastUpdated: 'now',
-					versionId: '1'
-				}
+					versionId: '1',
+				},
 			};
 
 			handler.readOne(req, res, results);
@@ -194,7 +194,9 @@ describe('FHIR Response Utility', () => {
 			expect(res.set.mock.calls[0][0]).toBe('Last-Modified');
 			// The dates wont be exact due to the time the test takes to run, we give
 			// ourselves a 60 second buffer incase the CI is slow or the test stalls
-			expect(Math.abs(expectedDate - lastModifiedTime) < tolerance).toBeTruthy();
+			expect(
+				Math.abs(expectedDate - lastModifiedTime) < tolerance,
+			).toBeTruthy();
 			expect(res.set.mock.calls[1][0]).toBe('Location');
 			expect(res.set.mock.calls[1][1]).toBe('4_0_0/Patient/foo');
 

--- a/packages/fhir-response-util/index.test.js
+++ b/packages/fhir-response-util/index.test.js
@@ -1,0 +1,259 @@
+const handler = require('./index.js');
+
+let req = {
+	protocol: 'https',
+	get: _prop => 'localhost:3000',
+	params: {
+		base_version: '4_0_0'
+	}
+};
+
+let res, end, json;
+
+describe('FHIR Response Utility', () => {
+	beforeEach(() => {
+		end = jest.fn();
+		json = jest.fn();
+		res = {
+			set: jest.fn(),
+			type: jest.fn(),
+			status: jest.fn(() => ({
+				end: end,
+				json: json
+			}))
+		};
+	});
+
+	describe('getContentType', () => {
+		test('should set correct content type for version', () => {
+			expect(handler.getContentType('1_0_2')).toBe('application/json+fhir');
+			expect(handler.getContentType('3_0_1')).toBe('application/fhir+json');
+			expect(handler.getContentType('4_0_0')).toBe('application/fhir+json');
+			expect(handler.getContentType('Unsupported')).toBe('application/json');
+		});
+	});
+
+	describe('read', () => {
+		test('should set the correct status code', () => {
+			let results = { results: 'GOLD' };
+			handler.read(req, res, results);
+
+			expect(res.type.mock.calls).toHaveLength(1);
+			expect(res.type.mock.calls[0][0]).toBe('application/fhir+json');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+		});
+
+		test('should invoke status().json with the results', () => {
+			let results = { results: 'GOLD' };
+			handler.read(req, res, results);
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+
+			expect(json.mock.calls).toHaveLength(1);
+			expect(json.mock.calls[0][0]).toBe(results);
+		});
+	});
+
+	describe('readOne', () => {
+		test('should set the correct status code', () => {
+			let results = { results: 'GOLD' };
+			handler.readOne(req, res, results);
+
+			expect(res.type.mock.calls).toHaveLength(1);
+			expect(res.type.mock.calls[0][0]).toBe('application/fhir+json');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+		});
+
+		test('should set the E-Tag and Last-Modified headers with metadata', () => {
+			let results = {
+				results: 'GOLD',
+				meta: {
+					lastUpdated: 'now',
+					versionId: '1'
+				}
+			};
+
+			handler.readOne(req, res, results);
+
+			expect(res.set.mock.calls).toHaveLength(2);
+			expect(res.set.mock.calls[0][0]).toBe('Last-Modified');
+			expect(res.set.mock.calls[0][1]).toBe(results.meta.lastUpdated);
+			expect(res.set.mock.calls[1][0]).toBe('ETag');
+			expect(res.set.mock.calls[1][1]).toBe(results.meta.versionId);
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+
+			expect(json.mock.calls).toHaveLength(1);
+			expect(json.mock.calls[0][0]).toBe(results);
+		});
+	});
+
+	describe('create', () => {
+		test('should set the correct status code', () => {
+			let results = { id: 'foo' };
+			handler.create(req, res, results, { type: 'Patient' });
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(201);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+
+		test('should set the E-Tag and Content-Location headers with version', () => {
+			let results = { id: 'foo', resource_version: '1' };
+			handler.create(req, res, results, { type: 'Patient' });
+
+			let expectedContentLocation =
+				'https://localhost:3000/4_0_0/Patient/foo/_history/1';
+
+			expect(res.set.mock.calls).toHaveLength(3);
+			expect(res.set.mock.calls[0][0]).toBe('Content-Location');
+			expect(res.set.mock.calls[0][1]).toBe(expectedContentLocation);
+			expect(res.set.mock.calls[1][0]).toBe('ETag');
+			expect(res.set.mock.calls[1][1]).toBe(results.resource_version);
+			expect(res.set.mock.calls[2][0]).toBe('Location');
+			expect(res.set.mock.calls[2][1]).toBe('4_0_0/Patient/foo');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(201);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+
+		test('should set the Location header with resource location', () => {
+			let results = { id: 'foo' };
+			handler.create(req, res, results, { type: 'Patient' });
+
+			expect(res.set.mock.calls).toHaveLength(1);
+			expect(res.set.mock.calls[0][0]).toBe('Location');
+			expect(res.set.mock.calls[0][1]).toBe('4_0_0/Patient/foo');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(201);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+	});
+
+	describe('update', () => {
+		test('should set the correct status code', () => {
+			let update = { id: 'foo', created: false };
+			let created = { id: 'foo', created: true };
+			handler.update(req, res, update, { type: 'Patient' });
+			handler.update(req, res, created, { type: 'Patient' });
+
+			expect(res.type.mock.calls).toHaveLength(2);
+			expect(res.type.mock.calls[0][0]).toBe('application/fhir+json');
+
+			expect(res.status.mock.calls).toHaveLength(2);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+			expect(res.status.mock.calls[1][0]).toBe(201);
+
+			expect(end.mock.calls).toHaveLength(2);
+		});
+
+		test('should set the correct response headers with version', () => {
+			let results = { id: 'foo', resource_version: '1', created: true };
+			handler.update(req, res, results, { type: 'Patient' });
+
+			let expectedContentLocation =
+				'https://localhost:3000/4_0_0/Patient/foo/_history/1';
+
+			// Should not set ETag if deleted prop is not present
+			expect(res.set.mock.calls).toHaveLength(4);
+			expect(res.set.mock.calls[0][0]).toBe('Content-Location');
+			expect(res.set.mock.calls[0][1]).toBe(expectedContentLocation);
+			expect(res.set.mock.calls[1][0]).toBe('ETag');
+			expect(res.set.mock.calls[1][1]).toBe(results.resource_version);
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(201);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+
+		test('should set the correct Location and Last-modified headers always', () => {
+			let results = { id: 'foo' };
+			// Number of milliseconds tolerance we want to allow
+			let expectedDate = new Date().getTime();
+			let tolerance = 60 * 1000;
+
+			handler.update(req, res, results, { type: 'Patient' });
+
+			expect(res.set.mock.calls).toHaveLength(2);
+
+			let lastModifiedISO = res.set.mock.calls[0][1];
+			let lastModifiedTime = new Date(lastModifiedISO).getTime();
+
+			expect(res.set.mock.calls[0][0]).toBe('Last-Modified');
+			// The dates wont be exact due to the time the test takes to run, we give
+			// ourselves a 60 second buffer incase the CI is slow or the test stalls
+			expect(Math.abs(expectedDate - lastModifiedTime) < tolerance).toBeTruthy();
+			expect(res.set.mock.calls[1][0]).toBe('Location');
+			expect(res.set.mock.calls[1][1]).toBe('4_0_0/Patient/foo');
+
+			expect(res.type.mock.calls).toHaveLength(1);
+			expect(res.type.mock.calls[0][0]).toBe('application/fhir+json');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+	});
+
+	describe('remove', () => {
+		test('should set the correct status code', () => {
+			handler.remove(req, res, {});
+
+			// Should not set ETag if deleted prop is not present
+			expect(res.set.mock.calls).toHaveLength(0);
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(204);
+
+			expect(end.mock.calls).toHaveLength(1);
+		});
+
+		test('should set the E-Tag header', () => {
+			handler.remove(req, res, { deleted: '123456789' });
+
+			expect(res.set.mock.calls).toHaveLength(1);
+			expect(res.set.mock.calls[0][0]).toBe('ETag');
+			expect(res.set.mock.calls[0][1]).toBe('123456789');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(204);
+		});
+	});
+
+	describe('history', () => {
+		test('should set the correct status code', () => {
+			let results = { results: 'GOLD' };
+			handler.history(req, res, results);
+
+			expect(res.type.mock.calls).toHaveLength(1);
+			expect(res.type.mock.calls[0][0]).toBe('application/fhir+json');
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+		});
+
+		test('should invoke status().json with the results', () => {
+			let results = { results: 'GOLD' };
+			handler.history(req, res, results);
+
+			expect(res.status.mock.calls).toHaveLength(1);
+			expect(res.status.mock.calls[0][0]).toBe(200);
+
+			expect(json.mock.calls).toHaveLength(1);
+			expect(json.mock.calls[0][0]).toBe(results);
+		});
+	});
+});

--- a/packages/fhir-response-util/index.test.js
+++ b/packages/fhir-response-util/index.test.js
@@ -165,7 +165,6 @@ describe('FHIR Response Utility', () => {
 			let expectedContentLocation =
 				'https://localhost:3000/4_0_0/Patient/foo/_history/1';
 
-			// Should not set ETag if deleted prop is not present
 			expect(res.set.mock.calls).toHaveLength(4);
 			expect(res.set.mock.calls[0][0]).toBe('Content-Location');
 			expect(res.set.mock.calls[0][1]).toBe(expectedContentLocation);
@@ -180,8 +179,8 @@ describe('FHIR Response Utility', () => {
 
 		test('should set the correct Location and Last-modified headers always', () => {
 			let results = { id: 'foo' };
-			// Number of milliseconds tolerance we want to allow
 			let expectedDate = new Date().getTime();
+			// Number of milliseconds tolerance we want to allow
 			let tolerance = 60 * 1000;
 
 			handler.update(req, res, results, { type: 'Patient' });
@@ -195,7 +194,7 @@ describe('FHIR Response Utility', () => {
 			// The dates wont be exact due to the time the test takes to run, we give
 			// ourselves a 60 second buffer incase the CI is slow or the test stalls
 			expect(
-				Math.abs(expectedDate - lastModifiedTime) < tolerance,
+				Math.abs(lastModifiedTime - expectedDate) < tolerance,
 			).toBeTruthy();
 			expect(res.set.mock.calls[1][0]).toBe('Location');
 			expect(res.set.mock.calls[1][1]).toBe('4_0_0/Patient/foo');

--- a/packages/fhir-response-util/package.json
+++ b/packages/fhir-response-util/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Utility for handling the headers, content, and status types for a response.",
   "main": "index.js",
-	"homepage": "https://github.com/Asymmetrik/phx-tools",
+  "homepage": "https://github.com/Asymmetrik/phx-tools",
   "repository": {
-		"type": "git",
-		"url": "https://github.com/Asymmetrik/phx-tools.git"
+    "type": "git",
+    "url": "https://github.com/Asymmetrik/phx-tools.git"
 	},
   "author": "Robert-W <rwinterbottom@asymmetrik.com>",
   "license": "MIT",

--- a/packages/fhir-response-util/package.json
+++ b/packages/fhir-response-util/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@asymmetrik/fhir-response-util",
+  "version": "1.0.0",
+  "description": "Utility for handling the headers, content, and status types for a response.",
+  "main": "index.js",
+	"homepage": "https://github.com/Asymmetrik/phx-tools",
+  "repository": {
+		"type": "git",
+		"url": "https://github.com/Asymmetrik/phx-tools.git"
+	},
+  "author": "Robert-W <rwinterbottom@asymmetrik.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "3a9dcc15708246b92bff6a208adff787555f7351"
+}


### PR DESCRIPTION
**New Package**: `@asymmetrik/fhir-response-util`

This adds a more generic than current response handler for the core library. This would also make the core library cleaner by removing the utility from core's source code and the brittle relative path require in the generated code, e.g. `require('../../../../utils/response.utils.js')`. 

Added tests, documentation, and examples.

**Breaking Changes:**

When this is merged into Core it will create some breaking changes so this will not go into core until version 2.0.0. The main change is the responsibility of casting the resources into FHIR resources. In 2.0.0, I plan to remove casting from response utils and encourage users to do it themselves in their services. They already have to do this when returning a bundle so this wont be a major change, they will just need to do it for all endpoints except create, update, and remove (they return JSON with only a few properties and not FHIR resources).

The service changes would look like this:

### Before (Version 1.3.1)
```javascript
module.exports.search = (args, context, logger) => new Promise((resolve, reject) => {
  logger.info('Searching ...');
  query(args).then(results => {
    return resolve(results);
  }).catch(err => {
    return reject(err);
  });
});
```

### After(Version 2.0.0)
```javascript
let {
  resolveFromVersion,
  loggers,
} = require('@asymmetrik/node-fhir-server-core');

const logger = loggers.get('default');

module.exports.search = (args, context) => new Promise((resolve, reject) => {
  logger.info('Searching ...');
  query(args).then(results => {
    // If the service supports only one version, they can do this at top of file and hardcode it
    let Patient = resolveFromVersion('patient', req.params.base_version);
    return resolve(new Patient(results));
  }).catch(err => {
    let OperationOutcome = resolveFromVersion('operationoutcome', req.params.base_version);
    return reject(new OperationOutcome(err));
  });
});
```

This way they can catch some errors and fix them outside of core, it also gives them more flexibility on errors since we force certain error types with only a few properties filled in, now they can provide all the text they want including the generated content if they choose.
