### PR TITLE
New package for secrets retrieval from AWS KMS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Core team members for FHIR at Asymmetrik
 
-* @Robert-W @jonterrylee
+* @Robert-W @jonterrylee @sshah-asymmetrik

--- a/packages/fhir-secrets/README.md
+++ b/packages/fhir-secrets/README.md
@@ -1,0 +1,60 @@
+# `FHIR-Secrets`
+
+> AWS KMS Secrets retrieval promisified.
+
+# Install
+
+```shell
+yarn add @asymmetrik/fhir-secrets
+```
+
+## Prerequisites
+
+* You will need an AWS Account.
+* You should have the CiphertextBlob you need to decrypt.
+* You can [authenticate with AWS](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html).
+
+## Usage
+Depending on where you are running this code, the setup portion may change. If you have a default AWS profile with region and everything else set, you can use the decrypt function as follows:
+
+```javascript
+const secrets = require('@asymmetrik/fhir-secrets');
+
+// This is output when you encrypt a secret with kms
+// https://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html
+let CiphertextBlob = 'somefakeblobcontent=';
+
+// Lets assume this blob contains metadata for a plaintext secret with value foobar
+secrets.decrypt({ CiphertextBlob })
+  .then(secret => {
+    console.log(secret);
+    // logs foobar
+  })
+  .catch(console.error);
+```
+
+If you need to configure the setup process with region or other properties in the client class constructor, you can do so and chain the process.
+
+```javascript
+const secrets = require('@asymmetrik/fhir-secrets');
+
+secrets.configure({ region: 'us-east-2' })
+  .decrypt({ CiphertextBlob: 'somefakeblobcontent=' })
+  .then(secret => doThingsWithSecret())
+  .catch(console.error);
+```
+
+See [fhir-secrets tests](https://github.com/Asymmetrik/phx-tools/blob/master/packages/fhir-secrets/index.test.js) for more usage examples.
+
+## Methods
+
+### configure
+> Configures the service class with any AWS or service class specific configurations.
+
+This takes a single options object. See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/KMS.html#constructor-property. It returns `this` so you can immediately call `decrypt` after configuring it.
+
+
+### decrypt
+> Wrapper on kms.decrypt but returns a promise which resolves the plain text of the secret.
+
+This takes a single options object. See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/KMS.html#decrypt-property. The only necessary property from this is `CiphertextBlob`.

--- a/packages/fhir-secrets/__mocks__/aws-sdk.js
+++ b/packages/fhir-secrets/__mocks__/aws-sdk.js
@@ -1,0 +1,36 @@
+'use strict';
+
+let KMS_INSTANCE = {
+	__params: {},
+	__error: undefined,
+	__results: undefined,
+
+	decrypt: (params, callback) => {
+		KMS_INSTANCE.__params = params;
+		callback(KMS_INSTANCE.__error, KMS_INSTANCE.__results);
+	},
+
+	__setError: function(err) {
+		KMS_INSTANCE.__error = err;
+	},
+
+	__setResults: function(data) {
+		KMS_INSTANCE.__results = data;
+	},
+
+	__reset: function() {
+		KMS_INSTANCE.__params = {};
+		KMS_INSTANCE.__error = undefined;
+		KMS_INSTANCE.__results = undefined;
+	},
+};
+
+let sdk = {
+	__config: {},
+	KMS: function(options) {
+		sdk.__config = options;
+		return KMS_INSTANCE;
+	},
+};
+
+module.exports = sdk;

--- a/packages/fhir-secrets/index.js
+++ b/packages/fhir-secrets/index.js
@@ -1,0 +1,47 @@
+const AWS = require('aws-sdk');
+
+// Create a default KMS Service object, this can be updated later
+let kms = new AWS.KMS();
+
+let secrets = {
+	/**
+	 * @function configure
+	 * @description Update AWS config for KMS service
+	 * @param {Object} options
+	 * @return {Object} this
+	 */
+	configure: function configure(options) {
+		kms = new AWS.KMS(options);
+		return this;
+	},
+
+	/**
+	 * @function decrypt
+	 * @description Takes a CiphertextBlob, returns a promise that resolves
+	 * 	to the plain text version of the secret
+	 * @param {Object} options - Options for kms.decrypt.
+	 * 	See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/KMS.html#decrypt-property
+	 * @return {Promise.<String, Error>}
+	 */
+	decrypt: function decrypt(options = {}) {
+		return new Promise((resolve, reject) => {
+			if (!options.CiphertextBlob) {
+				reject(new Error('Missing required argument property: CiphertextBlob'));
+			}
+
+			let params = Object.assign({}, options, {
+				CiphertextBlob: Buffer.from(options.CiphertextBlob, 'base64'),
+			});
+
+			kms.decrypt(params, (err, data) => {
+				if (err) {
+					return reject(err);
+				} else {
+					return resolve(data.Plaintext.toString('utf-8'));
+				}
+			});
+		});
+	},
+};
+
+module.exports = secrets;

--- a/packages/fhir-secrets/index.test.js
+++ b/packages/fhir-secrets/index.test.js
@@ -1,0 +1,61 @@
+const secrets = require('./index');
+const AWS = require('aws-sdk');
+
+let kms_instance = new AWS.KMS();
+
+describe('FHIR Secrets Test', () => {
+	describe('Method: configure', () => {
+		test('should pass options to AWS.KMS', () => {
+			let options = { region: 'us-east-2' };
+			expect(AWS.__config).not.toBe(options);
+
+			secrets.configure(options);
+			expect(AWS.__config).toBe(options);
+		});
+
+		test('should return self for chaining subsequent operations', () => {
+			let options = { region: 'us-east-2' };
+			let self = secrets.configure(options);
+
+			expect(self.configure).toBeDefined();
+			expect(self.decrypt).toBeDefined();
+		});
+	});
+
+	describe('Method: decrypt', () => {
+		beforeEach(() => {
+			kms_instance.__reset();
+		});
+
+		test('should resolve plain text secrets when successfully called', () => {
+			// Setup mock
+			kms_instance.__setResults({ Plaintext: 'foobar' });
+
+			expect.assertions(1);
+			return secrets
+				.decrypt({ CiphertextBlob: 'SomeFakeBlob=' })
+				.then(secret => {
+					expect(secret).toBe('foobar');
+				});
+		});
+
+		test('should pass any errors back in reject', () => {
+			// Setup mock
+			kms_instance.__setError('foobar');
+
+			expect.assertions(1);
+			return secrets.decrypt({ CiphertextBlob: 'SomeFakeBlob=' }).catch(err => {
+				expect(err).toBe('foobar');
+			});
+		});
+
+		test('should return expected error back for missing blob', () => {
+			expect.assertions(1);
+			return secrets.decrypt().catch(err => {
+				expect(err.message).toBe(
+					'Missing required argument property: CiphertextBlob',
+				);
+			});
+		});
+	});
+});

--- a/packages/fhir-secrets/package.json
+++ b/packages/fhir-secrets/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@asymmetrik/fhir-secrets",
+  "version": "0.9.0",
+  "description": "AWS KMS Secrets retrieval promisified",
+  "main": "index.js",
+  "homepage": "https://github.com/Asymmetrik/phx-tools",
+  "author": "Robert-W <rwinterbottom@asymmetrik.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Asymmetrik/phx-tools.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.435.0"
+  }
+}


### PR DESCRIPTION
Includes test, documentation, and has been prettified.

Usage is simple but requires AWS authentication. 

```javascript
const secrets = require('@asymmetrik/fhir-secrets');

secrets.configure({ region: 'us-east-2' })
  .decrypt({ CiphertextBlob: '' })
  .then(plaintext => doStuffWithSecret(plaintext))
  .catch(err => {
    // Unable to obtain secrets
  });

```